### PR TITLE
DRTII-991 Only provide est chox when there is an act runway time

### DIFF
--- a/src/main/scala/uk/gov/homeoffice/cirium/services/entities/CiriumEntities.scala
+++ b/src/main/scala/uk/gov/homeoffice/cirium/services/entities/CiriumEntities.scala
@@ -123,8 +123,10 @@ case class CiriumFlightStatus(flightId: Int,
 
   lazy val estimatedChox: Option[Long] = {
     (operationalTimes.actualRunwayArrival, operationalTimes.estimatedGateArrival) match {
-      case (Some(_), Some(CiriumDate(_, _, estChox))) if estChox != arrivalDate.millis => Option(estChox)
-      case _ => None
+      case (Some(_), Some(CiriumDate(_, _, estChox))) =>
+        Option(estChox)
+      case _ =>
+        None
     }
   }
 

--- a/src/main/scala/uk/gov/homeoffice/cirium/services/entities/CiriumEntities.scala
+++ b/src/main/scala/uk/gov/homeoffice/cirium/services/entities/CiriumEntities.scala
@@ -122,8 +122,8 @@ case class CiriumFlightStatus(flightId: Int,
   lazy val actualTouchdown: Option[Long] = operationalTimes.actualRunwayArrival.map(_.millis)
 
   lazy val estimatedChox: Option[Long] = {
-    operationalTimes.estimatedGateArrival match {
-      case Some(CiriumDate(_, _, estChox)) if estChox != arrivalDate.millis => Option(estChox)
+    (operationalTimes.actualRunwayArrival, operationalTimes.estimatedGateArrival) match {
+      case (Some(_), Some(CiriumDate(_, _, estChox))) if estChox != arrivalDate.millis => Option(estChox)
       case _ => None
     }
   }

--- a/src/test/scala/uk/gov/homeoffice/cirium/services/entities/CiriumFlightStatusSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/cirium/services/entities/CiriumFlightStatusSpec.scala
@@ -51,6 +51,10 @@ class CiriumFlightStatusSpec extends Specification {
       val cfs = Generator.ciriumFlightStatus(sch = scheduled, actRunway = actualRunway, estGate = estimatedGate)
       cfs.estimatedChox should ===(Option(DateTime.parse(estimatedGate).getMillis))
     }
+    "Give an estimated chox when it has an act runway even if the estimated gate time is the same as the scheduled time" in {
+      val cfs = Generator.ciriumFlightStatus(sch = scheduled, actRunway = actualRunway, estGate = scheduled)
+      cfs.estimatedChox should ===(Option(DateTime.parse(scheduled).getMillis))
+    }
 
     "Give an actual chox when it has an actual gate" in {
       val cfs = Generator.ciriumFlightStatus(sch = scheduled, actGate = actualGate)

--- a/src/test/scala/uk/gov/homeoffice/cirium/services/entities/CiriumFlightStatusSpec.scala
+++ b/src/test/scala/uk/gov/homeoffice/cirium/services/entities/CiriumFlightStatusSpec.scala
@@ -36,15 +36,19 @@ class CiriumFlightStatusSpec extends Specification {
     }
 
     "Give no estimated chox when it has no estimated gate" in {
-      val cfs = Generator.ciriumFlightStatus(sch = scheduled, estGate = "")
+      val cfs = Generator.ciriumFlightStatus(sch = scheduled, estRunway = actualRunway, estGate = "")
       cfs.estimatedChox should ===(None)
     }
-    "Give no estimated time when its estimated gate time is the same as scheduled" in {
-      val cfs = Generator.ciriumFlightStatus(sch = scheduled, estGate = scheduled)
+    "Give no estimated chox when its estimated gate time is the same as scheduled" in {
+      val cfs = Generator.ciriumFlightStatus(sch = scheduled, estRunway = actualRunway, estGate = scheduled)
       cfs.estimatedChox should ===(None)
     }
-    "Give an estimated time when its estimated gate time is different to scheduled" in {
-      val cfs = Generator.ciriumFlightStatus(sch = scheduled, estGate = estimatedGate)
+    "Give no estimated chox when it has no actual runway time even if est gate is different to scheduled" in {
+      val cfs = Generator.ciriumFlightStatus(sch = scheduled, actRunway = "", estGate = estimatedGate)
+      cfs.estimatedChox should ===(None)
+    }
+    "Give an estimated chox when its estimated gate time is different to scheduled and it has an act runway" in {
+      val cfs = Generator.ciriumFlightStatus(sch = scheduled, actRunway = actualRunway, estGate = estimatedGate)
       cfs.estimatedChox should ===(Option(DateTime.parse(estimatedGate).getMillis))
     }
 


### PR DESCRIPTION
Update to ignore estimated gate times as an est chox until we have an actual runway time